### PR TITLE
Removes invalid conversion error with newer gcc

### DIFF
--- a/LOFAR/LCS/Common/src/AddressTranslator.cc
+++ b/LOFAR/LCS/Common/src/AddressTranslator.cc
@@ -77,7 +77,7 @@ namespace LOFAR
 #endif
         }
         if (filename) {
-          char* h = strrchr(filename,'/');
+          const char* h = strrchr(filename,'/');
           if (h) {
             filename = h+1;
           }


### PR DESCRIPTION
While compiling with gcc version 4.8.4 (Ubuntu 4.8.4-2ubuntu1~14.04.3) on Ubuntu 14.04.5 LTS I get:

/home/kat/software/makems/LOFAR/LCS/Common/src/AddressTranslator.cc: In member function 'void LOFAR::AddressTranslator::operator( (std::vector<LOFAR::Backtrace::TraceLine>&, void* const*, int)':
/home/kat/software/makems/LOFAR/LCS/Common/src/AddressTranslator.cc:80:41: error: invalid conversion from 'const char*' to 'char*' [-fpermissive]
           char* h = strrchr(filename,'/');

changing pointer type to const char* will fix the issue. Alternative is to specify -fpermissive flag in cmake. Personally I prefer the first option.